### PR TITLE
cpu: efm32_common uart: fix rx pin direction

### DIFF
--- a/cpu/efm32_common/periph/uart.c
+++ b/cpu/efm32_common/periph/uart.c
@@ -61,7 +61,7 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     isr_ctx[dev].arg = arg;
 
     /* initialize the pins */
-    gpio_init(uart_config[dev].rx_pin, GPIO_OUT);
+    gpio_init(uart_config[dev].rx_pin, GPIO_IN);
     gpio_init(uart_config[dev].tx_pin, GPIO_OUT);
 
     /* initialize the UART/USART/LEUART device */


### PR DESCRIPTION
the currently configured rx pin direction is potentially dangerous, as the chip might drive against the communications partner. (i'm unsure whether this would have worked at all, eg. for the interactive terminal uart).
